### PR TITLE
Include level in the new kraken report filename

### DIFF
--- a/src/est_abundance.py
+++ b/src/est_abundance.py
@@ -419,7 +419,7 @@ def main():
             new_reads[curr_node.taxid] += add_reads 
     #Print modified kraken report 
     new_report, extension = os.path.splitext(args.input)
-    r_file = open(new_report + '_bracken' + extension, 'w')
+    r_file = open(new_report + '_bracken_' + abundance_lvl + extension, 'w')
     #r_file.write(unclassified_line)
     r_file.write("%0.2f\t" % (float(u_reads)/float(total_reads)*100))
     r_file.write("%i\t" % u_reads)


### PR DESCRIPTION
If you run this script multiple times, using different levels as input, the new kraken report that gets output has the same filename, and gets overwritten each time you run the script. With this change, you can run it multiple times using different levels, and each report has a unique name.

Alternatively, a new option could be created to specify the filename for the new kraken report.

Thanks!