### PR TITLE
Round redistributed read floats

### DIFF
--- a/src/est_abundance.py
+++ b/src/est_abundance.py
@@ -362,10 +362,10 @@ def main():
         o_file.write(name + '\t')
         o_file.write(taxid + '\t')
         o_file.write(args.level + '\t')
-        o_file.write(str(int(all_reads)) + '\t')
-        o_file.write(str(int(new_all_reads)-int(all_reads))+'\t')
-        o_file.write(str(int(new_all_reads)) + '\t')
-        o_file.write("%0.5f\n" % (float(new_all_reads)/float(sum_all_reads)))
+        o_file.write('%0.0f\t' % all_reads)
+        o_file.write('%0.0f\t' % (new_all_reads - all_reads))
+        o_file.write('%0.0f\t' % new_all_reads)
+        o_file.write('%0.5f\n' % (float(new_all_reads) / float(sum_all_reads)))
     o_file.close()
     
     #Print to screen
@@ -423,8 +423,8 @@ def main():
     r_file = open(new_report + '_bracken' + extension, 'w')
     #r_file.write(unclassified_line)
     r_file.write("%0.2f\t" % (float(u_reads)/float(total_reads)*100))
-    r_file.write("%i\t" % u_reads)
-    r_file.write("%i\t" % u_reads)
+    r_file.write("%0.0f\t" % u_reads)
+    r_file.write("%0.0f\t" % u_reads)
     r_file.write("U\t0\tunclassified\n")
     #For each current parent node, print to file 
     curr_nodes = [root_node]
@@ -446,9 +446,9 @@ def main():
         #Print information for this level
         new_all_reads = new_reads[curr_node.taxid]
         r_file.write("%0.2f\t" % (float(new_all_reads)/float(total_reads)*100))
-        r_file.write("%i\t" % (new_all_reads))
+        r_file.write("%0.0f\t" % new_all_reads)
         if children == 0:
-            r_file.write("%i\t" % (new_all_reads))
+            r_file.write("%0.0f\t" % new_all_reads)
         else:
             r_file.write("0\t")
         r_file.write(curr_node.level_id + "\t")


### PR DESCRIPTION
Hi Jennifer and Florian,

Thank you for developing Bracken, I've found it very useful in my work and I think it's a great addition to the Kraken classifier. I've discovered what may be a small bug and I thought I'd contribute back to your project by making a minor pull request.

I noticed that Bracken represents redistributed reads as floating point numbers and during output are cast to integers without rounding. This can cause off-by-one errors for the reported counts of a taxa. The affect of this is amplified in the Kraken-format report whereby these off-by-one inaccuracies are summed through the taxonomic tree and can result in larger discrepancies between the number of reads assigned to a clade (inclusive of all children nodes) and the sum of read counts assigned to individual nodes of that clade. Below is an excerpt from a report generated with Bracken which is affected by the described issue:

```
7.24    3183985 0       G       838                       Prevotella
2.64    1162821 1162821 S       52227                       Prevotella dentalis
1.84    808570  808570  S       76123                       Prevotella enoeca
1.19    523928  523928  S       28129                       Prevotella denticola
0.49    216241  216241  S       652716                      Prevotella sp. oral taxon 299
0.37    164928  164928  S       839                         Prevotella ruminicola
0.48    208994  208994  S       28131                       Prevotella intermedia
0.11    49136   49136   S       589436                      Prevotella fusca
0.07    30195   30195   S       1177574                     Prevotella jejuni
0.02    9006    9006    S       28132                       Prevotella melaninogenica
0.02    10160   10160   S       589437                      Prevotella scopos
```
Here the read count assigned to the Prevotella clade (3,183,985) does not equal the sum of reads assigned at each of the children nodes (3,183,979).

This pull request patches `src/est_abundance.py` to fix this behaviour by rounding the redistributed read counts prior to writing out the default Bracken report and the Kraken-style output format.