### PR TITLE
Recreate database if file exists but is empty.

### DIFF
--- a/bracken-build
+++ b/bracken-build
@@ -124,7 +124,7 @@ else
 fi
 #See if database.kraken exists, if not, create
 echo " >> Creating database.kraken [if not found]"
-if [ -f $DATABASE/database.kraken ]
+if [ -s $DATABASE/database.kraken ]
 then
     #database.kraken exists, skip
     echo "          database.kraken exists, skipping creation...."


### PR DESCRIPTION
If something went wrong during a previous attempt of `bracken-build`, `database.kraken` can be empty. If it is not created in that case, `bracken-build` will just create an empty database, which in turn causes errors such as Issue #99.

This avoids this by checking not only for the existence of `database.kraken` but also whether it is not empty.