### PR TITLE
Making the combine_bracken_outputs.py script python3 compatible

### DIFF
--- a/analysis_scripts/combine_bracken_outputs.py
+++ b/analysis_scripts/combine_bracken_outputs.py
@@ -130,7 +130,10 @@ def main():
     #Print each sample 
     for name in sample_counts:
         #Print information for classification
-        taxid = sample_counts[name].keys()[0]
+        if int(sys.version_info[0]) >= 3:
+            taxid = list(sample_counts[name].keys())[0]
+        else:
+            taxid = sample_counts[name].keys()[0]
         o_file.write("%s\t%s\t%s" % (name, taxid, level)) 
         #Calculate and print information per sample 
         for sample in all_samples:


### PR DESCRIPTION
With a small addition, the combine_bracken_outputs.py now works with python3. Tested successfully with python 2.7 and python 3.6