### PR TITLE
Fix wrong include and refactor Makefile to build cleanly on macOS

### DIFF
--- a/src/Makefile
+++ b/src/Makefile
@@ -1,13 +1,29 @@
-C++ = g++
-CFLAGS = -c -g -O3 -pedantic -std=c++11 -fopenmp 
+CXXFLAGS := -c -g -O3 -pedantic -std=c++11
 
-all: kmer_counter
+UNAME_S := $(shell uname -s)
+ifeq ($(UNAME_S),Darwin)
+	CXX := clang++
+else
+	CXX := g++
+endif
 
-kmer_counter: 	kmer2read_distr.o ctime.o taxonomy.o kraken_processing.o
-		$(C++) -o kmer2read_distr ctime.o kmer2read_distr.o taxonomy.o kraken_processing.o -lgomp
+IS_CLANG := $(findstring clang++,$(CXX))
+ifeq ($(IS_CLANG),clang++)
+	CXXFLAGS += -Xpreprocessor -fopenmp
+	LDFLAGS += -lomp
+else
+	CXXFLAGS += -fopenmp
+	LDFLAGS += -lgomp
+endif
+
+all: kmer2read_distr
+
+kmer2read_distr: kmer2read_distr.o ctime.o taxonomy.o kraken_processing.o
+	$(CXX) -o $@ $^ $(LDFLAGS)
 
 clean:
-		rm -f *.o
+	rm -f *.o
 
-%.o:	%.cpp
-		$(C++) $(CFLAGS) $*.cpp
+%.o: %.cpp
+	$(CXX) $(CXXFLAGS) $<
+

--- a/src/ctime.cpp
+++ b/src/ctime.cpp
@@ -19,7 +19,7 @@
  * Jennifer Lu, jlu26@jhmi.edu
  * Updated: 2018/09/06
  */
-#include "time.h"
+#include "ctime.h"
 
 /*************************************************************************
  *  METHOD: timeval_subtract


### PR DESCRIPTION
@martin-steinegger asked me earlier to look over why his conda recipe was failing.
This resolves two of the problems that require conda patching ( you should be able to remove the osx.patch and ctime.patch in conda in the next release).