### PR TITLE
Update est_abundance.py

### DIFF
--- a/src/est_abundance.py
+++ b/src/est_abundance.py
@@ -141,6 +141,8 @@ def process_kraken_report(curr_str):
     #Extract relevant information
     all_reads =  int(split_str[1])
     level_reads = int(split_str[2])
+    if all_reads < level_reads:
+        all_reads, level_reads = level_reads, all_reads
     #Account for krakenuniq 
     try:
         taxid = int(split_str[-3])


### PR DESCRIPTION
I believe I have found the cause of #225 (and possibly some other?!)

Some kraken reports generated seem to have the direct reads and descendant reads columns switched by comparison with your assumption in line 143 of `estimate_abundance.py`. This was causing taxa to be lost during bracken reestimations. Given that the count for all descendants includes the counts at a given taxonomic level it should be completely safe to just check and switch if necessary.

NB My kraken report was generated using the kraken2-server https://github.com/epi2me-labs/kraken2-server