### PR TITLE
Reduce memory overhead and exit early if not able to create database.…

### DIFF
--- a/bracken-build
+++ b/bracken-build
@@ -169,23 +169,33 @@ then
     #database.kraken.tsv exists, skip
     echo "          database.kraken.tsv exists, skipping creation...."
     ln -s $DATABASE/database.kraken.tsv $DATABASE/database.kraken
-elif [ $KRAKEN == "kraken2" ]
-then
-    #database.kraken not found, must create
-    echo "      >> ${KINSTALL}kraken2 --db $DATABASE --threads ${THREADS} <( find -L $DATABASE/library \( -name "*.fna" -o -name "*.fa" -o -name "*.fasta" \) -exec cat {} + ) > $DATABASE/database.kraken"
-
-    ${KINSTALL}kraken2 --db $DATABASE --threads ${THREADS} <( find -L $DATABASE/library \( -name "*.fna" -o -name "*.fa" -o -name "*.fasta" \) -exec cat {} + ) > $DATABASE/database.kraken
-elif [ $KRAKEN == "krakenuniq" ]
-then 
-    #database.kraken not found, must create
-    echo "      >> ${KINSTALL}krakenuniq --db $DATABASE --threads ${THREADS} <( find -L $DATABASE/library \( -name "*.fna" -o -name "*.fa" -o -name "*.fasta" \) -exec cat {} + ) > $DATABASE/database.kraken"
-    ${KINSTALL}krakenuniq --db $DATABASE --threads ${THREADS} <( find -L $DATABASE/library \( -name "*.fna" -o -name "*.fa" -o -name "*.fasta" \) -exec cat {} + ) > $DATABASE/database.kraken
 else
-    #database.kraken not found, must create
-    echo "      >> ${KINSTALL}kraken --db $DATABASE --threads ${THREADS} <( find -L $DATABASE/library \( -name "*.fna" -o -name "*.fa" -o -name "*.fasta" \) -exec cat {} + ) > $DATABASE/database.kraken"
-    ${KINSTALL}kraken --db $DATABASE --threads ${THREADS} <( find -L $DATABASE/library \( -name "*.fna" -o -name "*.fa" -o -name "*.fasta" \) -exec cat {} + ) > $DATABASE/database.kraken
+    filenames=`find -L $DATABASE/library \( -name "*.fna" -o -name "*.fa" -o -name "*.fasta" \) -print`
+    if [ $KRAKEN == "kraken2" ]
+    then
+        #database.kraken not found, must create
+        echo "      >> ${KINSTALL}kraken2 --db $DATABASE --threads ${THREADS} $filenames > $DATABASE/database.kraken.tmp"
+        ${KINSTALL}kraken2 --db $DATABASE --threads ${THREADS} $filenames > $DATABASE/database.kraken.tmp
+    elif [ $KRAKEN == "krakenuniq" ]
+    then
+        #database.kraken not found, must create
+        echo "      >> ${KINSTALL}krakenuniq --db $DATABASE --threads ${THREADS} $filenames > $DATABASE/database.kraken.tmp"
+        ${KINSTALL}krakenuniq --db $DATABASE --threads ${THREADS} $filenames > $DATABASE/database.kraken.tmp
+    else
+        #database.kraken not found, must create
+        echo "      >> ${KINSTALL}kraken --db $DATABASE --threads ${THREADS} $filenames > $DATABASE/database.kraken.tmp"
+        ${KINSTALL}kraken --db $DATABASE --threads ${THREADS} $filenames > $DATABASE/database.kraken.tmp
+    fi
+
+if [ $0 -eq 0 ]
+then
+    mv $DATABASE/database.kraken.tmp $DATABASE/database.kraken
+    echo "          Finished creating database.kraken [in DB folder]"
+else
+    rm $DATABASE/database.kraken.tmp
+    echo "          Unable to create database.kraken [in DB folder]"
+    exit 1
 fi
-echo "          Finished creating database.kraken [in DB folder]"
 #Generate databaseXmers.kmer_distrib
 #DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 DIR=`dirname $(readlink $0 || echo $0)`


### PR DESCRIPTION
This PR seeks to address two issues:

### 1. Reduce memory overhead during the creation of `database.kraken` 
It seeks to avoid any *potential* memory overhead incurred by having the `find` command concatenate the FASTAs  and input that data to  the `classifier` via process substitution.

### 2. Exit early if failed to build `database.kraken` 
The change-set alters the behavior of the build script to finalize the name of the database only if the build process has successfully completed. This avoids potential false positives when running `bracken-build` in a loop as demonstrated below:

```
for i in {50,75,100}; do
    bracken-build -d . -t 12 -l $i
done
```

Currently, if `bracken-build` fails for read length `50` the loop will still continue since `database.kraken` exists regardless of whether the previous invocation succeeded or not. This will have the cascading effect of read length 75 and 100 being processed on a potentially truncated database.