### PR TITLE
Speed up kmer_distr especially for longer reads

### DIFF
--- a/bracken-build
+++ b/bracken-build
@@ -169,23 +169,33 @@ then
     #database.kraken.tsv exists, skip
     echo "          database.kraken.tsv exists, skipping creation...."
     ln -s $DATABASE/database.kraken.tsv $DATABASE/database.kraken
-elif [ $KRAKEN == "kraken2" ]
-then
-    #database.kraken not found, must create
-    echo "      >> ${KINSTALL}kraken2 --db $DATABASE --threads ${THREADS} <( find -L $DATABASE/library \( -name "*.fna" -o -name "*.fa" -o -name "*.fasta" \) -exec cat {} + ) > $DATABASE/database.kraken"
-
-    ${KINSTALL}kraken2 --db $DATABASE --threads ${THREADS} <( find -L $DATABASE/library \( -name "*.fna" -o -name "*.fa" -o -name "*.fasta" \) -exec cat {} + ) > $DATABASE/database.kraken
-elif [ $KRAKEN == "krakenuniq" ]
-then 
-    #database.kraken not found, must create
-    echo "      >> ${KINSTALL}krakenuniq --db $DATABASE --threads ${THREADS} <( find -L $DATABASE/library \( -name "*.fna" -o -name "*.fa" -o -name "*.fasta" \) -exec cat {} + ) > $DATABASE/database.kraken"
-    ${KINSTALL}krakenuniq --db $DATABASE --threads ${THREADS} <( find -L $DATABASE/library \( -name "*.fna" -o -name "*.fa" -o -name "*.fasta" \) -exec cat {} + ) > $DATABASE/database.kraken
 else
-    #database.kraken not found, must create
-    echo "      >> ${KINSTALL}kraken --db $DATABASE --threads ${THREADS} <( find -L $DATABASE/library \( -name "*.fna" -o -name "*.fa" -o -name "*.fasta" \) -exec cat {} + ) > $DATABASE/database.kraken"
-    ${KINSTALL}kraken --db $DATABASE --threads ${THREADS} <( find -L $DATABASE/library \( -name "*.fna" -o -name "*.fa" -o -name "*.fasta" \) -exec cat {} + ) > $DATABASE/database.kraken
+    filenames=`find -L $DATABASE/library \( -name "*.fna" -o -name "*.fa" -o -name "*.fasta" \) -print`
+    if [ $KRAKEN == "kraken2" ]
+    then
+        #database.kraken not found, must create
+        echo "      >> ${KINSTALL}kraken2 --db $DATABASE --threads ${THREADS} $filenames > $DATABASE/database.kraken.tmp"
+        ${KINSTALL}kraken2 --db $DATABASE --threads ${THREADS} $filenames > $DATABASE/database.kraken.tmp
+    elif [ $KRAKEN == "krakenuniq" ]
+    then
+        #database.kraken not found, must create
+        echo "      >> ${KINSTALL}krakenuniq --db $DATABASE --threads ${THREADS} $filenames > $DATABASE/database.kraken.tmp"
+        ${KINSTALL}krakenuniq --db $DATABASE --threads ${THREADS} $filenames > $DATABASE/database.kraken.tmp
+    else
+        #database.kraken not found, must create
+        echo "      >> ${KINSTALL}kraken --db $DATABASE --threads ${THREADS} $filenames > $DATABASE/database.kraken.tmp"
+        ${KINSTALL}kraken --db $DATABASE --threads ${THREADS} $filenames > $DATABASE/database.kraken.tmp
+    fi
+
+if [ $0 -eq 0 ]
+then
+    mv $DATABASE/database.kraken.tmp $DATABASE/database.kraken
+    echo "          Finished creating database.kraken [in DB folder]"
+else
+    rm $DATABASE/database.kraken.tmp
+    echo "          Unable to create database.kraken [in DB folder]"
+    exit 1
 fi
-echo "          Finished creating database.kraken [in DB folder]"
 #Generate databaseXmers.kmer_distrib
 #DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"
 DIR=`dirname $(readlink $0 || echo $0)`

--- a/bracken-build
+++ b/bracken-build
@@ -185,16 +185,16 @@ else
         #database.kraken not found, must create
         echo "      >> ${KINSTALL}kraken --db $DATABASE --threads ${THREADS} $filenames > $DATABASE/database.kraken.tmp"
         ${KINSTALL}kraken --db $DATABASE --threads ${THREADS} $filenames > $DATABASE/database.kraken.tmp
-    fi
 
-if [ $0 -eq 0 ]
-then
-    mv $DATABASE/database.kraken.tmp $DATABASE/database.kraken
-    echo "          Finished creating database.kraken [in DB folder]"
-else
-    rm $DATABASE/database.kraken.tmp
-    echo "          Unable to create database.kraken [in DB folder]"
-    exit 1
+    if [ $0 -eq 0 ]
+    then
+        mv $DATABASE/database.kraken.tmp $DATABASE/database.kraken
+        echo "          Finished creating database.kraken [in DB folder]"
+    else
+        rm $DATABASE/database.kraken.tmp
+        echo "          Unable to create database.kraken [in DB folder]"
+        exit 1
+    fi
 fi
 #Generate databaseXmers.kmer_distrib
 #DIR="$( cd "$( dirname "${BASH_SOURCE[0]}" )" >/dev/null && pwd )"

--- a/src/Makefile
+++ b/src/Makefile
@@ -1,10 +1,10 @@
 CXXFLAGS := -c -g -O3 -pedantic -std=c++11
 
 UNAME_S := $(shell uname -s)
-ifeq ($(UNAME_S),Darwin)
-	CXX := clang++
+ifeq ($(UNAME_S),Linux)
+	CXX ?= g++
 else
-	CXX := g++
+	CXX ?= clang++
 endif
 
 IS_CLANG := $(findstring clang++,$(CXX))

--- a/src/kraken_processing.cpp
+++ b/src/kraken_processing.cpp
@@ -7,7 +7,7 @@
  * it under the terms of the GNU General Public License as published by
  * the Free Software Foundation; either version 3 of the license, or
  * (at your option) any later version.
- * 
+ *
  * This program is distributed in the hope that it will be useful,
  * but WITHOUT ANY WARRANTY; without even the implied warranty of
  * MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
@@ -19,231 +19,155 @@
  * Jennifer Lu, jlu26@jhmi.edu
  * Updated: 2022/03/31
  */
+#include <set>
+
 #include "kraken_processing.h"
 
-/*METHOD: Evaluate the kraken database file*/
-void evaluate_kfile(string k_file, string o_file, const taxonomy *my_taxonomy, const map<int, taxonomy *> *taxid2node, const map<string, int> seqid2taxid, const int kmer_len, const int read_len){
-    /*Parallel Variables*/
-    
-    FILE * kraken_file = fopen(k_file.c_str(),"r");
-    int fd = fileno(kraken_file);
-    struct stat sb;
-    fstat(fd,&sb);
-    size_t dataSize = sb.st_size;
-    char * data = static_cast<char*>(mmap(NULL, dataSize, PROT_READ,MAP_PRIVATE,fd,0));
-    size_t globalLineCounter = 0;
-    
-    int seqs_read = 0; 
-    /*Iterate over kraken file in parallel*/
-    printf("\t>>STEP 3: CONVERTING KMER MAPPINGS INTO READ CLASSIFICATIONS:\n");
-    printf("\t\t%imers, with a database built using %imers\n",read_len, kmer_len);
-    cerr << "\t\t0 sequences converted...";
-    //Open file to append
-    ofstream outfile;
-    outfile.open(o_file, ofstream::out);
-    #pragma omp parallel 
-    {
-        bool processMore = true;
-        size_t lastReadPos = 0;
-        size_t newLineCnt = 0;
-        size_t i;
-        //Get the line and process
-        while(processMore) {
-            //Get line number
-            int currLineToProcess = __sync_fetch_and_add(&globalLineCounter,1);
-            //Get line 
-            for (i = lastReadPos; i < dataSize; i++){
-                newLineCnt += (data[i]=='\n');
-                if(newLineCnt == currLineToProcess){ 
-                    char * lineStart = &data[i + (data[i]=='\n' ? 1 : 0)];
-                    size_t pos=0; 
-                    while(lineStart[pos] != '\n' && (i + pos) < dataSize){
-                        pos++;
+#include <limits>
+
+struct TaxidInfo {
+    int count;
+    int score;
+    std::set<int> active_ancestors;
+    std::set<int> ancestors_seen;
+    bool active_ancestors_updated;
+};
+
+// Second idea: Change the logic so that a kmer links to all the taxids that
+// depend on it. That way instead of scanning the active kmers to find out who
+// to update we will instead have a list of dependents that we know we have to
+// update. Any dependent with a count of 0, we remove from the set because it
+// has fallen off.
+class KmerClassifier {
+ public:
+    KmerClassifier() {
+        scores[0].count = 0;
+        scores[1].count = 0;
+    }
+
+    int
+    classify_kmers(int kmer_to_add, int kmer_to_remove,
+                   const std::map<int, taxonomy *> *taxid2node) {
+        if (kmer_to_remove >= 0) {
+            scores[kmer_to_remove].count -= 1;
+            scores[kmer_to_remove].score -= 1;
+
+            if (scores[kmer_to_remove].count == 0) {
+                active_kmers.erase(kmer_to_remove);
+            }
+        }
+
+        bool new_kmer = false;
+
+        if (kmer_to_add > 1) {
+             if (active_kmers.find(kmer_to_add) == active_kmers.end()) {
+                new_kmer = true;
+                active_kmers.insert(kmer_to_add);
+                scores[kmer_to_add].count = 0;
+                scores[kmer_to_add].score = 0;
+                scores[kmer_to_add].active_ancestors_updated = true;
+            }
+
+            if (new_kmer) {
+                taxonomy *new_node = taxid2node->find(kmer_to_add)->second;
+                auto comp = [] (taxonomy *a, taxonomy *b) {
+                    return a->get_lvl_num() < b->get_lvl_num();
+                };
+
+                std::vector<taxonomy *> nodes;
+                nodes.reserve(active_kmers.size() - 1);
+
+                for (auto it = active_kmers.begin(); it != active_kmers.end(); it++) {
+                    taxonomy *node = taxid2node->find(*it)->second;
+                    if (node != new_node) {
+                        nodes.push_back(node);
                     }
-                    char * lineEnd = &lineStart[pos]; 
-                    string kraken_line(lineStart, lineEnd - lineStart);
-                    //Variables for things to save
-                    string seqid = "";
-                    int taxid = -1;
-                    map<int, int> taxids_mapped;
-                    //CALL METHOD TO PROCESS THE LINE
-                    convert_line(kraken_line, &seqid2taxid, read_len, kmer_len, my_taxonomy, taxid2node, seqid, taxid, taxids_mapped); 
-                    //PRINT FOR LINE
-                    #pragma omp atomic
-                    seqs_read += 1;
-                    #pragma omp critical
-                    {
-                        cerr << "\r\t\t" << seqs_read << " sequences converted (finished: ";
-                        cerr << seqid << ")";
-                        //Print read information
-                        outfile << seqid << "\t"; 
-                        outfile << taxid << "\t"; 
-                        outfile << "" << "\t"; 
-                        //Print distributions
-                        for (map<int, int>::iterator it=taxids_mapped.begin(); it!=taxids_mapped.end(); ++it){
-                            outfile << it->first << ":" << it->second << " ";
+                }
+
+                std::sort(nodes.begin(), nodes.end(), comp);
+
+                while (nodes.size() != 0) {
+                    auto node = nodes.back();
+                    auto taxid = node->get_taxid();
+
+                    if (node->get_lvl_num() < new_node->get_lvl_num()) {
+                        break;
+                    } else if (scores[taxid].ancestors_seen.find(kmer_to_add) != scores[taxid].ancestors_seen.end()) {
+                        scores[taxid].score += 1;
+                        scores[taxid].active_ancestors.insert(kmer_to_add);
+                    } else {
+                        while (node->get_parent() != NULL && node->get_lvl_num() > new_node->get_lvl_num()) {
+                            node = node->get_parent();
                         }
-                        outfile << "\n";
+                        if (node->get_taxid() == kmer_to_add) {
+                            scores[taxid].score += 1;
+                            scores[taxid].active_ancestors.insert(kmer_to_add);
+                            scores[taxid].ancestors_seen.insert(kmer_to_add);
+                        }
                     }
-                    lastReadPos = i+1; 
-                    break;
+                    nodes.pop_back();
                 }
-            }
-            if(i == dataSize) {
-                processMore = false;
-            }
-        }
-    }
-    cerr << "\r\t\t" << globalLineCounter << " sequences converted\n";
 
-}
-/***************************************************************************************/
-/*METHOD: CONVERT DISTRIBUTIONS INTO READ MAPPINGS - SEND TO PRINT*/
-void convert_line(string line, const map<string,int> *seqid2taxid, const int read_len, const int kmer_len, const taxonomy *my_taxonomy, const map<int, taxonomy *> *taxid2node, string &seqid, int &taxid, map<int,int> &taxids_mapped){ 
-   
-    //Find delimiter indices
-    int pos1, pos2, pos3, pos4, pos5;
-    pos1 = line.find("\t");
-    pos2 = line.find("\t", pos1+1);
-    pos3 = line.find("\t", pos2+1);
-    pos4 = line.find("\t", pos3+1);
-    pos5 = line.find("\n", pos4+1);
-    //Extract seqid and taxid 
-    seqid = line.substr(pos1+1, pos2-pos1-1);
-    taxid = seqid2taxid->find(seqid)->second;
-    string curr_ks = line.substr(pos4+1, pos5-pos4-1);
-
-    /*Initialize variables for getting read mappings instead of kmer mappings */
-    int n_kmers = read_len - kmer_len + 1;
-    
-    //Saving values 
-    vector<int> all_kmers;
-    int count_kmers = 0;
-    //Iterate through all of the kmer pairs 
-    int mid, end; 
-    string buf; 
-    std::stringstream ss(curr_ks);
-    int pair_taxid, pair_count;
-    string curr_pair, pair_tstr;
-    while(ss >> buf) {
-        //Extract the string of this pair
-        curr_pair = buf;
-        //Split up this pair into the taxid and the number of kmers
-        mid = curr_pair.find(":");
-        end = curr_pair.find("\n"); 
-        pair_tstr = curr_pair.substr(0,mid);
-        pair_count = atoi(curr_pair.substr(mid+1,end-mid-1).c_str());
-        if (pair_tstr == "A")
-            pair_taxid = 0;
-        else
-            pair_taxid = atoi(pair_tstr.c_str());
-        //Add kmers to queue
-        for (int j = 0; j < pair_count; j++) {
-            all_kmers.push_back(pair_taxid);
-            count_kmers += 1;
-        }
-    }
-    //Process all mappings
-    vector<int> curr_kmers; 
-    int mapped_taxid;
-    int prev_kmer, next_kmer; 
-    int prev_taxid; 
-    for (int k = 0; k < count_kmers; k++) {
-        next_kmer = all_kmers[k];
-        curr_kmers.push_back(next_kmer);
-        if (curr_kmers.size() == n_kmers) {
-            if (prev_kmer == next_kmer) {
-                mapped_taxid = prev_taxid;
-            } else {
-                mapped_taxid = get_classification(&curr_kmers, my_taxonomy, taxid2node);
-            } 
-            //if (mapped_taxid != 0) {
-            //Save to map
-            auto t_it = taxids_mapped.find(mapped_taxid);
-            if (t_it == taxids_mapped.end()){
-                taxids_mapped[mapped_taxid] = 1;
-                //.insert(std::pair<int,int>(mapped_taxid, 1));
-            } else {
-                t_it->second += 1;
-            }
-            prev_taxid = mapped_taxid;
-            //Remove last element
-            prev_kmer = curr_kmers[0];
-            curr_kmers.erase(curr_kmers.begin());
-        } 
-    }
-}
-
-
-/***************************************************************************************/
-/*METHOD: Process the array of the kmer distributions*/ 
-int get_classification(vector<int> *curr_kmers, const taxonomy *my_taxonomy, const map<int, taxonomy *> *taxid2node) {
-    //Initialize values
-    map<int, int> taxid2kmers; 
-    int count_ts = 0;
-    int curr_t; 
-    int save_t; 
-    int found_root = 0;
-    //Figure out number of taxids in current list 
-    for (int i = 0; i < curr_kmers->size(); i++) {
-        //Get the first kmer out 
-        curr_t = curr_kmers->at(i);  
-        //Check for unclassified 
-        if (curr_t == 0){
-            continue;
-        } else if (curr_t == 1){
-            found_root = 1;
-            continue;   
-        }
-        //Save taxids
-        auto x_it = taxid2kmers.find(curr_t);
-        if (x_it == taxid2kmers.end()) {
-            //Not found in map
-            count_ts += 1;
-            save_t = curr_t;
-            taxid2kmers[curr_t] = 1;
-        } else {
-            x_it->second += 1;
-        }
-    }
-    //Determine what to send back
-    if (count_ts == 0) {
-        if (found_root != 0){
-            return 1;
-        } else {
-            return 0;
-        }
-    } else if (count_ts == 1) {
-        return save_t; 
-    } else {
-        //MUST MAKE THIS FASTER SOMEHOWWW
-        //can i sort by node numbers? while array has something -- pop if visit.....
-        //Score each taxid -- make faster by ignoring taxids already visited? 
-        map<int, int> taxid2scores; 
-        taxonomy * curr_n;
-        for (map<int, int>::iterator it=taxid2kmers.begin(); it!=taxid2kmers.end(); ++it){
-            taxid2scores[it->first] = it->second;
-            curr_n = taxid2node->find(it->first)->second;
-            while(curr_n->get_parent() != NULL) {
-                curr_n = curr_n->get_parent();
-                if (taxid2kmers.find(curr_n->get_taxid()) != taxid2kmers.end()) {
-                    taxid2scores[it->first] += taxid2kmers[curr_n->get_taxid()];
+                taxonomy *curr_n = new_node;
+                auto score = scores[kmer_to_add];
+                while (!nodes.empty()) {
+                    auto node = nodes.back();
+                    if (scores[kmer_to_add].ancestors_seen.find(node->get_taxid()) != scores[kmer_to_add].ancestors_seen.end()) {
+                        scores[kmer_to_add].score += scores[node->get_taxid()].count;
+                        scores[kmer_to_add].active_ancestors.insert(node->get_taxid());
+                    } else {
+                        curr_n = new_node;
+                        while (curr_n->get_parent() != NULL /* && curr_n->get_lvl_num() < node->get_lvl_num()*/) {
+                            curr_n = curr_n->get_parent();
+                            if (curr_n->get_taxid() == nodes.back()->get_taxid()) {
+                                scores[kmer_to_add].score += scores[curr_n->get_taxid()].count;
+                                scores[kmer_to_add].active_ancestors.insert(curr_n->get_taxid());
+                                scores[kmer_to_add].ancestors_seen.insert(curr_n->get_taxid());
+                            }
+                        }
+                    }
+                    nodes.pop_back();
                 }
             }
         }
-        //Find the maximum score 
+
+        scores[kmer_to_add].count += 1;
+        scores[kmer_to_add].score += 1;
+
+        if (active_kmers.size() == 0) {
+            if (scores[1].count > 0) {
+                return 1;
+            } else {
+                return 0;
+            }
+        }
+
         int max_score = 0;
         int max_taxid = 0;
-        for (map<int, int>::iterator it=taxid2scores.begin(); it!=taxid2scores.end(); ++it){
-            if (it->second > max_score){
-                //Get max scoring
-                max_score = it->second;
-                max_taxid = it->first;
-            } else if (it->second == max_score){
-                //Break ties 
-                taxonomy * n1 = taxid2node->find(it->first)->second;
-                taxonomy * n2 = taxid2node->find(max_taxid)->second;
-                //Get to the same level 
+        for (auto it = active_kmers.begin(); it != active_kmers.end(); it++) {
+            if (!new_kmer || *it != kmer_to_add) {
+                auto not_found = scores[*it].active_ancestors.end();
+                auto item1 = scores[*it].active_ancestors.find(kmer_to_remove);
+                auto item2 = new_kmer ? not_found : scores[*it].active_ancestors.find(kmer_to_add);
+
+                if (item1 != not_found) {
+                    scores[*it].score -= 1;
+                    if (scores[kmer_to_remove].count == 0)
+                        scores[*it].active_ancestors.erase(item1);
+                }
+
+                if (item2 != not_found) {
+                    scores[*it].score += 1;
+                }
+            }
+
+            if (scores[*it].score > max_score) {
+                max_score = scores[*it].score;
+                max_taxid = *it;
+            } else if (scores[*it].score == max_score) {
+                taxonomy *n1 = taxid2node->find(*it)->second;
+                taxonomy *n2 = taxid2node->find(max_taxid)->second;
+                //Get to the same level
                 while (n1->get_lvl_num() > n2->get_lvl_num()) {
                     if (n1->get_parent() == NULL){
                         cerr << n1->get_taxid() << endl;
@@ -265,6 +189,211 @@ int get_classification(vector<int> *curr_kmers, const taxonomy *my_taxonomy, con
                 max_taxid = n1->get_taxid();
             }
         }
+
         return max_taxid;
     }
+
+    void reset() {
+        scores[0].count = 0;
+        scores[0].score = 0;
+        scores[1].count = 0;
+        scores[1].score = 0;
+
+        for (auto it = active_kmers.begin(); it != active_kmers.end(); ++it) {
+            scores[*it].count = 0;
+            scores[*it].score = 0;
+        }
+
+        active_kmers.clear();
+    }
+
+ private:
+ std::set<int> active_kmers;
+ std::map<int, TaxidInfo> scores;
+};
+
+inline unsigned int fast_atou(const char *str)
+{
+    unsigned int val = 0;
+    while(*str) {
+        val = (val << 1) + (val << 3) + *(str++) - 48;
+    }
+    return val;
+}
+
+/*METHOD: Evaluate the kraken database file*/
+void evaluate_kfile(string k_file, string o_file, const taxonomy *my_taxonomy, const map<int, taxonomy *> *taxid2node, const map<string, int> seqid2taxid, const int kmer_len, const int read_len){
+    /*Parallel Variables*/
+
+    FILE * kraken_file = fopen(k_file.c_str(),"r");
+    int fd = fileno(kraken_file);
+    struct stat sb;
+    fstat(fd,&sb);
+    size_t dataSize = sb.st_size;
+    char * data = static_cast<char*>(mmap(NULL, dataSize, PROT_READ,MAP_PRIVATE,fd,0));
+    size_t globalLineCounter = 0;
+
+    int seqs_read = 0;
+    /*Iterate over kraken file in parallel*/
+    printf("\t>>STEP 3: CONVERTING KMER MAPPINGS INTO READ CLASSIFICATIONS:\n");
+    printf("\t\t%imers, with a database built using %imers\n",read_len, kmer_len);
+    cerr << "\t\t0 sequences converted...";
+    //Open file to append
+    ofstream outfile;
+    outfile.open(o_file, ofstream::out);
+
+    #pragma omp parallel
+    {
+        bool processMore = true;
+        size_t lastReadPos = 0;
+        size_t newLineCnt = 0;
+        size_t i;
+        string kraken_line;
+        KmerClassifier classifier;
+
+        //Get the line and process
+        while(processMore) {
+            //Get line number
+            int currLineToProcess = __sync_fetch_and_add(&globalLineCounter,1);
+            //Get line
+            for (i = lastReadPos; i < dataSize; i++){
+                newLineCnt += (data[i]=='\n');
+                if(newLineCnt == currLineToProcess){
+                    char * lineStart = &data[i + (data[i]=='\n' ? 1 : 0)];
+                    size_t pos=0;
+                    while(lineStart[pos] != '\n' && (i + pos) < dataSize){
+                        pos++;
+                    }
+                    char *lineEnd = &lineStart[pos];
+                    size_t len = lineEnd - lineStart;
+                    kraken_line.resize(len);
+                    kraken_line.assign(lineStart, len);
+                    //Variables for things to save
+                    string seqid = "";
+                    int taxid = -1;
+                    std::map<int, int> taxids_mapped;
+
+                    //CALL METHOD TO PROCESS THE LINE
+                    convert_line(kraken_line, &seqid2taxid, read_len, kmer_len, my_taxonomy, taxid2node, seqid, taxid, taxids_mapped, classifier);
+                    //PRINT FOR LINE
+                    #pragma omp atomic
+                    seqs_read += 1;
+                    #pragma omp critical
+                    {
+                        cerr << "\r\t\t" << seqs_read << " sequences converted (finished: ";
+                        cerr << seqid << ")";
+                        //Print read information
+                        outfile << seqid << "\t";
+                        outfile << taxid << "\t";
+                        outfile << "" << "\t";
+                        //Print distributions
+                        for (auto it=taxids_mapped.begin(); it!=taxids_mapped.end(); ++it){
+                            outfile << it->first << ":" << it->second << " ";
+                        }
+                        outfile << "\n";
+                    }
+                    lastReadPos = i+1;
+                    break;
+                }
+            }
+            if(i == dataSize) {
+                processMore = false;
+            }
+        }
+    }
+    cerr << "\r\t\t" << globalLineCounter << " sequences converted\n";
+
+}
+
+// /***************************************************************************************/
+// /*METHOD: CONVERT DISTRIBUTIONS INTO READ MAPPINGS - SEND TO PRINT*/
+void convert_line(string line, const std::map<string,int> *seqid2taxid, const int read_len, const int kmer_len, const taxonomy *my_taxonomy, const std::map<int, taxonomy *> *taxid2node, string &seqid, int &taxid, std::map<int,int> &taxids_mapped, KmerClassifier &classifier){
+    int pos1, pos2, pos3, pos4, pos5;
+    pos1 = line.find("\t");
+    pos2 = line.find("\t", pos1+1);
+    pos3 = line.find("\t", pos2+1);
+    pos4 = line.find("\t", pos3+1);
+    pos5 = line.find("\n", pos4+1);
+    //Extract seqid and taxid
+    seqid = line.substr(pos1 + 1, pos2 - pos1 - 1);
+    taxid = seqid2taxid->find(seqid)->second;
+    char *curr_ks = &line[pos4 + 1];
+
+    /*Initialize variables for getting read mappings instead of kmer mappings */
+    int n_kmers = read_len - kmer_len + 1;
+
+    //Saving values
+    vector<std::pair<int, int>> all_kmers;
+    size_t count_kmers = 0;
+    //Iterate through all of the kmer pairs
+    int mid, end;
+    int pair_taxid, pair_count;
+    string curr_pair, pair_tstr;
+    size_t len = line.size() - pos4;
+    size_t n_alloc = 0;
+    curr_ks[len - 1] = ' ';
+    for (int i = 0; i < len; i++) {
+        if (curr_ks[i] == ' ')
+          n_alloc++;
+    }
+    all_kmers.reserve(n_alloc);
+    for (size_t i = 0; i < len; i++) {
+        // Split up this pair into the taxid and the number of kmers
+        char *data = &curr_ks[i];
+        char *mid = (char *)memchr(data, (int)':', len - i);
+        if (mid == NULL) break;
+        char *end = (char *)memchr(data, (int)' ', len - i);
+        *mid = '\0';
+        *end  = '\0';
+        pair_count = fast_atou(mid + 1);
+        if (data[0] == 'A')
+            pair_taxid = 0;
+        else {
+            pair_taxid = fast_atou(data);
+        }
+        // Add kmers to queue
+        all_kmers.push_back(std::make_pair(pair_taxid, pair_count));
+        count_kmers += 1;
+
+        i = end - curr_ks;
+    }
+
+    //Process all mappings
+    deque<int> curr_kmers;
+    int mapped_taxid = -1;
+    uint32_t prev_kmer = -1, next_kmer;
+    uint32_t prev_taxid;
+    uint32_t hash1, hash2;
+    size_t hash;
+
+    for (int k = 0; k < count_kmers; k++) {
+        next_kmer = all_kmers[k].first;
+        int count = all_kmers[k].second;
+        for (int j = 0; j < count; j++) {
+            curr_kmers.push_back(next_kmer);
+            if (curr_kmers.size() == n_kmers) {
+                if (prev_kmer == next_kmer) {
+                    mapped_taxid = prev_taxid;
+                } else {
+                    mapped_taxid = classifier.classify_kmers(
+                        next_kmer, prev_kmer, taxid2node);
+                }
+                //Save to map
+                auto t_it = taxids_mapped.find(mapped_taxid);
+                if (t_it == taxids_mapped.end()){
+                    taxids_mapped[mapped_taxid] = 1;
+                    //.insert(std::pair<int,int>(mapped_taxid, 1));
+                } else {
+                    t_it->second += 1;
+                }
+                prev_taxid = mapped_taxid;
+                //Remove last element
+                prev_kmer = curr_kmers.front();
+                curr_kmers.pop_front();
+            } else {
+                classifier.classify_kmers(next_kmer, prev_kmer, taxid2node);
+            }
+        }
+    }
+    classifier.reset();
 }

--- a/src/kraken_processing.h
+++ b/src/kraken_processing.h
@@ -26,11 +26,16 @@
 #include "taxonomy.h"
 #include "ctime.h"
 #include <sys/mman.h>
+
+#include <deque>
+
+class KmerClassifier;
+
 void evaluate_kfile(string, string, const taxonomy *, const map<int, taxonomy *> *, map<string, int>, const int, const int);
 
-void convert_line(string, const map<string, int> *, const int, const int, const taxonomy *, const map<int, taxonomy *> *, string &, int &, map<int,int> &);
+void convert_line(string, const map<string, int> *, const int, const int, const taxonomy *, const map<int, taxonomy *> *, string &, int &, std::map<int,int> &, KmerClassifier &);
 
-int get_classification(vector<int> *, const taxonomy *, const map<int, taxonomy *> *);
+int get_classification(deque<int> &, const taxonomy *, const map<int, taxonomy *> *);
 
 
 #endif

--- a/src/taxonomy.cpp
+++ b/src/taxonomy.cpp
@@ -48,38 +48,3 @@ taxonomy::taxonomy(int taxid, string level_type, taxonomy *parent) {
 /*Destructor */ 
 taxonomy::~taxonomy() {
 }
-
-/*Accessor Methods*/
-
-int taxonomy::get_taxid() const {
-    return this->taxid; 
-}
-
-int taxonomy::get_lvl_num() const {
-    return this->lvl_num;
-}
-
-string taxonomy::get_lvl_type() const {
-    return this->lvl_type;
-}
-
-taxonomy* taxonomy::get_parent() const{
-    return this->parent;
-}
-
-vector<taxonomy *> taxonomy::get_children() const {
-    return this->children;
-}
-
-/*Methods for manipulating the tree*/
-void taxonomy::add_parent(taxonomy *parent) {
-    this->parent = parent;
-}
-
-void taxonomy::add_child(taxonomy *new_child) {
-    this->children.push_back(new_child);
-}
-
-void taxonomy::set_lvl_num(int num) {
-    this->lvl_num = num;
-}

--- a/src/taxonomy.h
+++ b/src/taxonomy.h
@@ -52,6 +52,40 @@ class taxonomy{
         int lvl_num;
         string lvl_type;
         vector<taxonomy *> children;
-        taxonomy *parent;  
+        taxonomy *parent;
 };
+
+/*Accessor Methods*/
+
+inline int taxonomy::get_taxid() const { return this->taxid; }
+
+inline int taxonomy::get_lvl_num() const {
+    return this->lvl_num;
+}
+
+inline string taxonomy::get_lvl_type() const {
+    return this->lvl_type;
+}
+
+inline taxonomy* taxonomy::get_parent() const{
+    return this->parent;
+}
+
+inline vector<taxonomy *> taxonomy::get_children() const {
+    return this->children;
+}
+
+/*Methods for manipulating the tree*/
+inline void taxonomy::add_parent(taxonomy *parent) {
+    this->parent = parent;
+}
+
+inline void taxonomy::add_child(taxonomy *new_child) {
+    this->children.push_back(new_child);
+}
+
+inline void taxonomy::set_lvl_num(int num) {
+    this->lvl_num = num;
+}
+
 #endif


### PR DESCRIPTION
This pull requests includes the following changes
  * `database.kraken` parser has been rewritten to  reduce memory overhead and slightly faster parsing of integers
  * The kmer classifier has been re-written to reduce redundant work, only consulting the taxonomy tree when needed

In my testing using `631 MB` `database.kraken` generated from a `Krakan 2` database that includes  `protozoa`, `plasmid` and `viral` libraries

Old code
* Read length 50: 1m 45s
* Read length 300: 10m

New code
* Read length 50: 51s
* Read length 300: 1m 20s

I also realized that bracken would sometimes report erroneous taxids (potential overflow?). This has been corrected in this patch as evidenced below.

```
< kraken:taxid|1028729|NW_017607663.1   1028729         -547168256:896 
---
> kraken:taxid|1028729|NW_017607663.1   1028729         0:896 
93965c93965
< kraken:taxid|1028729|NW_017607667.1   1028729         -547174400:471 
---
> kraken:taxid|1028729|NW_017607667.1   1028729         0:471 
93970c93970
< kraken:taxid|1028729|NW_017607672.1   1028729         -528441344:571 
---
> kraken:taxid|1028729|NW_017607672.1   1028729         0:571 
93999c93999
< kraken:taxid|1028729|NW_017607701.1   1028729         -547168256:596 
---
> kraken:taxid|1028729|NW_017607701.1   1028729         0:596 
94001c94001
< kraken:taxid|1028729|NW_017607703.1   1028729         -528433152:1084 
---
> kraken:taxid|1028729|NW_017607703.1   1028729         0:1084 
```
